### PR TITLE
Binary metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ tapyrus::TxOut supports marker output.
 ```rust
 use tapyrus::{Script, TxOut};
 use tapyrus::blockdata::script::Builder;
+use tapyrus::consensus::serialize;
 use tapyrus::util::misc::hex_bytes;
 use hex::decode as hex_decode;
-use openassets::marker_output::{TxOutExt, Payload};
+use openassets::marker_output::{Metadata, TxOutExt, Payload};
 
 let marker_output = TxOut {value: 0, script_pubkey: Builder::from(hex_decode("6a244f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71").unwrap()).into_script()};
 
@@ -25,14 +26,14 @@ let payload: Payload = marker_output.get_oa_payload().unwrap();
 
 // asset quantities
 payload.quantities;
-=> [127, 128, 12857]
+=> [100, 0, 123]
 
 // metadata
-payload.metadata
+payload.metadata.to_string()
 => "u=https://cpr.sm/5YgSU1Pg-q"
 
 // encode payload
-let metadata = "u=https://cpr.sm/5YgSU1Pg-q".to_string();
+let metadata = Metadata("u=https://cpr.sm/5YgSU1Pg-q".as_bytes().to_vec());
 let payload = Payload { quantities: vec![100, 0, 123], metadata };
 let serialized_marker: Vec<u8> = serialize(&payload);
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
-
-extern crate tapyrus;
-extern crate hex;
-extern crate byteorder;
 extern crate bitcoin_hashes;
+extern crate byteorder;
 extern crate core;
+extern crate hex;
+extern crate tapyrus;
 
 pub mod openassets;

--- a/src/openassets/address.rs
+++ b/src/openassets/address.rs
@@ -1,67 +1,74 @@
+use std::fmt::{self, Display, Formatter};
+use tapyrus::consensus::encode;
+use tapyrus::consensus::encode::Error::ParseFailed;
 use tapyrus::network::constants::Network;
 use tapyrus::util::address::Payload;
-use tapyrus::consensus::encode;
-use std::fmt::{self, Display, Formatter};
 use tapyrus::util::base58;
-use tapyrus::consensus::encode::Error::ParseFailed;
 
 /// A Open Assets Address
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Address {
-
     pub network: Network,
     pub payload: Payload,
-
 }
 
 const NAMESPACE: u8 = 0x13;
 
 impl Address {
-
-    pub fn new(payload: Payload, network: tapyrus::network::constants::Network) -> Result<Self, encode::Error> {
+    pub fn new(
+        payload: Payload,
+        network: tapyrus::network::constants::Network,
+    ) -> Result<Self, encode::Error> {
         match payload {
-            Payload::PubkeyHash(_) | Payload::ScriptHash(_) => {},
-            _ => {return Err(ParseFailed("The Open Assets Address of the witness program does not defined."));}
+            Payload::PubkeyHash(_) | Payload::ScriptHash(_) => {}
+            _ => {
+                return Err(ParseFailed(
+                    "The Open Assets Address of the witness program does not defined.",
+                ));
+            }
         }
         Ok(Address { payload, network })
     }
 
     pub fn to_btc_addr(&self) -> Result<tapyrus::Address, encode::Error> {
-        Ok(tapyrus::Address {network: self.network, payload: self.payload.clone()})
+        Ok(tapyrus::Address {
+            network: self.network,
+            payload: self.payload.clone(),
+        })
     }
 }
 
-impl Display for Address{
+impl Display for Address {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         let mut prefixed = [0; 22];
         prefixed[0] = NAMESPACE;
         prefixed[1] = match self.network {
-            tapyrus::network::constants::Network::Bitcoin | tapyrus::network::constants::Network::Paradium => 0,
-            tapyrus::network::constants::Network::Testnet | tapyrus::network::constants::Network::Regtest => 111,
+            tapyrus::network::constants::Network::Bitcoin
+            | tapyrus::network::constants::Network::Paradium => 0,
+            tapyrus::network::constants::Network::Testnet
+            | tapyrus::network::constants::Network::Regtest => 111,
         };
         match self.payload {
             Payload::PubkeyHash(ref hash) => {
                 prefixed[2..].copy_from_slice(&hash[..]);
                 base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
-            },
+            }
             Payload::ScriptHash(ref hash) => {
                 prefixed[2..].copy_from_slice(&hash[..]);
                 base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
-            },
+            }
             Payload::WitnessProgram(_) => {
                 fmt.write_str("The Open Assets Address of the witness program does not defined.")
-            },
+            }
         }
     }
 }
 
 pub trait OAAddressConverter {
-
     fn to_oa_address(&self) -> Result<Address, encode::Error>;
-
 }
 
-impl OAAddressConverter for tapyrus::Address{
+impl OAAddressConverter for tapyrus::Address {
     fn to_oa_address(&self) -> Result<Address, encode::Error> {
         Address::new(self.payload.clone(), self.network)
     }
@@ -69,23 +76,32 @@ impl OAAddressConverter for tapyrus::Address{
 
 #[cfg(test)]
 mod tests {
+    use openassets::address::OAAddressConverter;
     use std::str::FromStr;
     use std::string::ToString;
-    use openassets::address::OAAddressConverter;
 
     #[test]
-    fn test_oa_address_converter(){
+    fn test_oa_address_converter() {
         let addr = tapyrus::Address::from_str("1F2AQr6oqNtcJQ6p9SiCLQTrHuM9en44H8").unwrap();
-        assert_eq!("akQz3f1v9JrnJAeGBC4pNzGNRdWXKan4U6E", addr.to_oa_address().unwrap().to_string());
+        assert_eq!(
+            "akQz3f1v9JrnJAeGBC4pNzGNRdWXKan4U6E",
+            addr.to_oa_address().unwrap().to_string()
+        );
         assert_eq!(addr, addr.to_oa_address().unwrap().to_btc_addr().unwrap());
 
+        let testnet_addr =
+            tapyrus::Address::from_str("mkgW6hNYBctmqDtTTsTJrsf2Gh2NPtoCU4").unwrap();
+        assert_eq!(
+            "bWvePLsBsf6nThU3pWVZVWjZbcJCYQxHCpE",
+            testnet_addr.to_oa_address().unwrap().to_string()
+        );
+        assert_eq!(
+            testnet_addr,
+            testnet_addr.to_oa_address().unwrap().to_btc_addr().unwrap()
+        );
 
-        let testnet_addr = tapyrus::Address::from_str("mkgW6hNYBctmqDtTTsTJrsf2Gh2NPtoCU4").unwrap();
-        assert_eq!("bWvePLsBsf6nThU3pWVZVWjZbcJCYQxHCpE", testnet_addr.to_oa_address().unwrap().to_string());
-        assert_eq!(testnet_addr, testnet_addr.to_oa_address().unwrap().to_btc_addr().unwrap());
-
-        let segwit_addr = tapyrus::Address::from_str("bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw").unwrap();
+        let segwit_addr =
+            tapyrus::Address::from_str("bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw").unwrap();
         assert!(segwit_addr.to_oa_address().is_err());
     }
-
 }

--- a/src/openassets/asset_id.rs
+++ b/src/openassets/asset_id.rs
@@ -7,26 +7,27 @@ use tapyrus::Script;
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AssetId {
-
     pub hash: bitcoin_hashes::hash160::Hash,
-    pub network: tapyrus::network::constants::Network
-
+    pub network: tapyrus::network::constants::Network,
 }
 
 impl AssetId {
-
-    pub fn new(script: &Script, network: tapyrus::network::constants::Network) -> AssetId{
-        AssetId { hash: hash160::Hash::hash(&script.to_bytes()), network}
+    pub fn new(script: &Script, network: tapyrus::network::constants::Network) -> AssetId {
+        AssetId {
+            hash: hash160::Hash::hash(&script.to_bytes()),
+            network,
+        }
     }
-
 }
 
-impl Display for AssetId{
+impl Display for AssetId {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         let mut prefixed = [0; 21];
         prefixed[0] = match self.network {
-            tapyrus::network::constants::Network::Bitcoin | tapyrus::network::constants::Network::Paradium => 0x17,
-            tapyrus::network::constants::Network::Testnet | tapyrus::network::constants::Network::Regtest => 0x73
+            tapyrus::network::constants::Network::Bitcoin
+            | tapyrus::network::constants::Network::Paradium => 0x17,
+            tapyrus::network::constants::Network::Testnet
+            | tapyrus::network::constants::Network::Regtest => 0x73,
         };
         prefixed[1..].copy_from_slice(&self.hash[..]);
         base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
@@ -41,13 +42,17 @@ impl FromStr for AssetId {
         let (network, hash) = match data[0] {
             0x17 => (
                 tapyrus::network::constants::Network::Bitcoin,
-                hash160::Hash::from_slice(&data[1..]).unwrap()
+                hash160::Hash::from_slice(&data[1..]).unwrap(),
             ),
             0x73 => (
                 tapyrus::network::constants::Network::Testnet,
-                hash160::Hash::from_slice(&data[1..]).unwrap()
+                hash160::Hash::from_slice(&data[1..]).unwrap(),
             ),
-            x   => return Err(encode::Error::Base58(base58::Error::InvalidVersion(vec![x])))
+            x => {
+                return Err(encode::Error::Base58(base58::Error::InvalidVersion(vec![
+                    x,
+                ])))
+            }
         };
         Ok(AssetId { hash, network })
     }
@@ -55,22 +60,38 @@ impl FromStr for AssetId {
 
 #[cfg(test)]
 mod tests {
+    use hex::decode as hex_decode;
+    use openassets::asset_id::AssetId;
     use std::str::FromStr;
     use tapyrus::blockdata::script::Builder;
-    use openassets::asset_id::AssetId;
-    use hex::decode as hex_decode;
 
     #[test]
     fn test_calculate_asset_id() {
-        let p2pkh = Builder::from(hex_decode("76a914010966776006953d5567439e5e39f86a0d273bee88ac").unwrap()).into_script();
+        let p2pkh = Builder::from(
+            hex_decode("76a914010966776006953d5567439e5e39f86a0d273bee88ac").unwrap(),
+        )
+        .into_script();
         let p2pkh_asset = AssetId::new(&p2pkh, tapyrus::network::constants::Network::Bitcoin);
-        assert_eq!("ALn3aK1fSuG27N96UGYB1kUYUpGKRhBuBC", p2pkh_asset.to_string());
-        assert_eq!(AssetId::from_str("ALn3aK1fSuG27N96UGYB1kUYUpGKRhBuBC").unwrap(), p2pkh_asset);
+        assert_eq!(
+            "ALn3aK1fSuG27N96UGYB1kUYUpGKRhBuBC",
+            p2pkh_asset.to_string()
+        );
+        assert_eq!(
+            AssetId::from_str("ALn3aK1fSuG27N96UGYB1kUYUpGKRhBuBC").unwrap(),
+            p2pkh_asset
+        );
 
-        let p2sh  = Builder::from(hex_decode("a914f9d499817e88ef7b10a88673296c6d6df2f4292d87").unwrap()).into_script();
+        let p2sh =
+            Builder::from(hex_decode("a914f9d499817e88ef7b10a88673296c6d6df2f4292d87").unwrap())
+                .into_script();
         let testnet_asset = AssetId::new(&p2sh, tapyrus::network::constants::Network::Testnet);
-        assert_eq!("oMb2yzA542yQgwn8XtmGefTzBv5NJ2nDjh", testnet_asset.to_string());
-        assert_eq!(AssetId::from_str("oMb2yzA542yQgwn8XtmGefTzBv5NJ2nDjh").unwrap(), testnet_asset);
+        assert_eq!(
+            "oMb2yzA542yQgwn8XtmGefTzBv5NJ2nDjh",
+            testnet_asset.to_string()
+        );
+        assert_eq!(
+            AssetId::from_str("oMb2yzA542yQgwn8XtmGefTzBv5NJ2nDjh").unwrap(),
+            testnet_asset
+        );
     }
-
 }

--- a/src/openassets/marker_output.rs
+++ b/src/openassets/marker_output.rs
@@ -1,5 +1,5 @@
 use std::io::{Read, Write};
-use std::string::FromUtf8Error;
+use std::fmt;
 
 use tapyrus::blockdata::script::Instruction;
 use tapyrus::consensus::encode::Error;
@@ -80,9 +80,12 @@ impl Decodable for Payload {
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Metadata(Vec<u8>);
 
-impl Metadata {
-    pub fn to_string(&self) -> Result<String, FromUtf8Error> {
-        String::from_utf8(self.0.clone())
+impl fmt::Display for Metadata {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match String::from_utf8(self.0.clone()) {
+            Ok(s) => write!(f, "{}", s),
+            _ => panic!("invalid utf-8 string") 
+        }
     }
 }
 
@@ -292,7 +295,7 @@ mod tests {
         assert_eq!(vec![100, 0, 123], payload.quantities);
         assert_eq!(
             "u=https://cpr.sm/5YgSU1Pg-q".to_string(),
-            payload.metadata.to_string().unwrap()
+            payload.metadata.to_string()
         );
 
         // empty metadata

--- a/src/openassets/marker_output.rs
+++ b/src/openassets/marker_output.rs
@@ -1,4 +1,5 @@
 use std::io::{Read, Write};
+use std::string::FromUtf8Error;
 
 use tapyrus::blockdata::script::Instruction;
 use tapyrus::consensus::encode::Error;
@@ -11,7 +12,7 @@ pub const VERSION: u16 = 0x0100;
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Payload {
     pub quantities: Vec<u64>,
-    pub metadata: String,
+    pub metadata: Metadata,
 }
 
 impl Encodable for Payload {
@@ -76,6 +77,27 @@ impl Decodable for Payload {
     }
 }
 
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct Metadata(Vec<u8>);
+
+impl Metadata {
+    pub fn to_string(&self) -> Result<String, FromUtf8Error> {
+        String::from_utf8(self.0.clone())
+    }
+}
+
+impl Encodable for Metadata {
+    fn consensus_encode<S: Write>(&self, s: S) -> Result<usize, Error> {
+        self.0.consensus_encode(s)
+    }
+}
+
+impl Decodable for Metadata {
+    fn consensus_decode<D: Read>(d: D) -> Result<Metadata, Error> {
+        Ok(Metadata(Decodable::consensus_decode(d)?))
+    }
+}
+
 pub trait TxOutExt {
     fn get_op_return_data(&self) -> Vec<u8>;
 
@@ -122,7 +144,7 @@ impl TxOutExt for TxOut {
 #[cfg(test)]
 mod tests {
     use hex::decode as hex_decode;
-    use openassets::marker_output::{Payload, TxOutExt};
+    use openassets::marker_output::{Metadata, Payload, TxOutExt};
     use tapyrus::blockdata::script::Builder;
     use tapyrus::consensus::serialize;
     use tapyrus::util::misc::hex_bytes;
@@ -268,7 +290,10 @@ mod tests {
         };
         let payload: Payload = marker_output.get_oa_payload().unwrap();
         assert_eq!(vec![100, 0, 123], payload.quantities);
-        assert_eq!("u=https://cpr.sm/5YgSU1Pg-q", payload.metadata);
+        assert_eq!(
+            "u=https://cpr.sm/5YgSU1Pg-q".to_string(),
+            payload.metadata.to_string().unwrap()
+        );
 
         // empty metadata
         let marker_output = TxOut {
@@ -277,7 +302,21 @@ mod tests {
         };
         let payload: Payload = marker_output.get_oa_payload().unwrap();
         assert_eq!(vec![1, 68], payload.quantities);
-        assert_eq!("", payload.metadata);
+        assert_eq!(Vec::<u8>::new(), payload.metadata.0);
+
+        // binary metadata
+        let marker_output = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(
+                hex_decode("6a104f4101000201440801020304fffefdfc").unwrap(),
+            )
+            .into_script(),
+        };
+        let payload: Payload = marker_output.get_oa_payload().unwrap();
+        assert_eq!(
+            vec![0x01, 0x02, 0x03, 0x04, 0xff, 0xfe, 0xfd, 0xfc],
+            payload.metadata.0
+        );
 
         // test for leb128
         let marker_output = TxOut {
@@ -291,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_encode_payload() {
-        let metadata = "u=https://cpr.sm/5YgSU1Pg-q".to_string();
+        let metadata = Metadata("u=https://cpr.sm/5YgSU1Pg-q".as_bytes().to_vec());
         let payload = Payload {
             quantities: vec![100, 0, 123],
             metadata,
@@ -303,7 +342,7 @@ mod tests {
             result
         );
 
-        let metadata = "".to_string();
+        let metadata = Metadata(vec![]);
         let payload = Payload {
             quantities: vec![1, 68],
             metadata,
@@ -311,8 +350,20 @@ mod tests {
         let result: Vec<u8> = serialize(&payload);
         assert_eq!(hex_decode("4f41010002014400").unwrap(), result);
 
+        // binary metadata
+        let metadata = Metadata(vec![0x01, 0x02, 0x03, 0x04, 0xff, 0xfe, 0xfd, 0xfc]);
+        let payload = Payload {
+            quantities: vec![1, 68],
+            metadata,
+        };
+        let result: Vec<u8> = serialize(&payload);
+        assert_eq!(
+            hex_decode("4f4101000201440801020304fffefdfc").unwrap(),
+            result
+        );
+
         // test for leb128
-        let metadata = "".to_string();
+        let metadata = Metadata(vec![]);
         let payload = Payload {
             quantities: vec![127, 128, 12857],
             metadata,

--- a/src/openassets/marker_output.rs
+++ b/src/openassets/marker_output.rs
@@ -1,19 +1,17 @@
 use std::io::{Read, Write};
 
 use tapyrus::blockdata::script::Instruction;
-use tapyrus::{TxOut, VarInt};
-use tapyrus::consensus::{Decodable, deserialize, Encodable};
 use tapyrus::consensus::encode::Error;
+use tapyrus::consensus::{deserialize, Decodable, Encodable};
+use tapyrus::{TxOut, VarInt};
 
 pub const MARKER: u16 = 0x4f41;
 pub const VERSION: u16 = 0x0100;
 
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub struct Payload{
-
+pub struct Payload {
     pub quantities: Vec<u64>,
-    pub metadata: String
-
+    pub metadata: String,
 }
 
 impl Encodable for Payload {
@@ -27,11 +25,15 @@ impl Encodable for Payload {
             loop {
                 let mut byte = value & 0x7F;
                 value >>= 7;
-                if value != 0 {byte |= 0x80;}
+                if value != 0 {
+                    byte |= 0x80;
+                }
                 len += Encodable::consensus_encode(&(byte as u8), &mut s)?;
-                if value == 0 { break;}
+                if value == 0 {
+                    break;
+                }
             }
-        };
+        }
         len += self.metadata.consensus_encode(&mut s)?;
         Ok(len)
     }
@@ -58,19 +60,23 @@ impl Decodable for Payload {
             loop {
                 let b: u8 = Decodable::consensus_decode(&mut d)?;
                 value |= ((b as u64) & 0x7f) << offset;
-                if (b as u64) & 0x80 == 0 { break;}
+                if (b as u64) & 0x80 == 0 {
+                    break;
+                }
                 offset += 7;
             }
             quantities.push(value);
         }
 
-        let payload = Payload { quantities, metadata: Decodable::consensus_decode(d)? };
+        let payload = Payload {
+            quantities,
+            metadata: Decodable::consensus_decode(d)?,
+        };
         return Ok(payload);
     }
 }
 
-pub trait TxOutExt{
-
+pub trait TxOutExt {
     fn get_op_return_data(&self) -> Vec<u8>;
 
     fn is_openassets_marker(&self) -> bool;
@@ -78,8 +84,7 @@ pub trait TxOutExt{
     fn get_oa_payload(&self) -> Result<Payload, Error>;
 }
 
-impl TxOutExt for TxOut{
-
+impl TxOutExt for TxOut {
     fn get_op_return_data(&self) -> Vec<u8> {
         if self.script_pubkey.is_op_return() {
             let mut script_iter = self.script_pubkey.iter(false);
@@ -88,9 +93,9 @@ impl TxOutExt for TxOut{
             if item.is_some() {
                 return match item.unwrap() {
                     Instruction::PushBytes(value) => value.to_vec(),
-                    _ => vec![]
+                    _ => vec![],
                 };
-            } else{
+            } else {
                 return vec![];
             }
         } else {
@@ -116,81 +121,170 @@ impl TxOutExt for TxOut{
 
 #[cfg(test)]
 mod tests {
-    use tapyrus::{Script, TxOut};
-    use tapyrus::blockdata::script::Builder;
-    use tapyrus::util::misc::hex_bytes;
     use hex::decode as hex_decode;
-    use openassets::marker_output::{TxOutExt, Payload};
+    use openassets::marker_output::{Payload, TxOutExt};
+    use tapyrus::blockdata::script::Builder;
     use tapyrus::consensus::serialize;
+    use tapyrus::util::misc::hex_bytes;
+    use tapyrus::{Script, TxOut};
 
     #[test]
-    fn test_op_return_data(){
+    fn test_op_return_data() {
         // op return data
-        let script: Script = Builder::from(hex_decode("6a244f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71").unwrap()).into_script();
-        let txout = TxOut {value: 0, script_pubkey: script};
-        assert_eq!(hex_bytes("4f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71").unwrap(), txout.get_op_return_data());
+        let script: Script = Builder::from(
+            hex_decode(
+                "6a244f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71",
+            )
+            .unwrap(),
+        )
+        .into_script();
+        let txout = TxOut {
+            value: 0,
+            script_pubkey: script,
+        };
+        assert_eq!(
+            hex_bytes("4f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71")
+                .unwrap(),
+            txout.get_op_return_data()
+        );
 
         // no op return
-        let script: Script = Builder::from(hex_decode("76a91446c2fbfbecc99a63148fa076de58cf29b0bcf0b088ac").unwrap()).into_script();
-        let no_data = TxOut {value: 0, script_pubkey: script};
+        let script: Script = Builder::from(
+            hex_decode("76a91446c2fbfbecc99a63148fa076de58cf29b0bcf0b088ac").unwrap(),
+        )
+        .into_script();
+        let no_data = TxOut {
+            value: 0,
+            script_pubkey: script,
+        };
         assert_eq!(0, no_data.get_op_return_data().len());
     }
 
     #[test]
-    fn test_is_openassets_marker(){
+    fn test_is_openassets_marker() {
         // no op return
-        let no_data = TxOut {value: 0, script_pubkey: Builder::from(hex_decode("76a91446c2fbfbecc99a63148fa076de58cf29b0bcf0b088ac").unwrap()).into_script()};
+        let no_data = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(
+                hex_decode("76a91446c2fbfbecc99a63148fa076de58cf29b0bcf0b088ac").unwrap(),
+            )
+            .into_script(),
+        };
         assert!(!no_data.is_openassets_marker());
 
         // valid marker
-        let valid_marker = TxOut {value: 0, script_pubkey: Builder::from(hex_decode("6a244f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71").unwrap()).into_script()};
+        let valid_marker = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(
+                hex_decode(
+                    "6a244f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71",
+                )
+                .unwrap(),
+            )
+            .into_script(),
+        };
         assert!(valid_marker.is_openassets_marker());
 
         // invalid marker
-        let invalid_marker = TxOut {value: 0, script_pubkey: Builder::from(hex_decode("6a4f4201000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71").unwrap()).into_script()};
+        let invalid_marker = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(
+                hex_decode(
+                    "6a4f4201000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71",
+                )
+                .unwrap(),
+            )
+            .into_script(),
+        };
         assert!(!invalid_marker.is_openassets_marker());
 
         // invalid version
-        let invalid_marker = TxOut {value: 0, script_pubkey: Builder::from(hex_decode("6a4f4102000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71").unwrap()).into_script()};
+        let invalid_marker = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(
+                hex_decode(
+                    "6a4f4102000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71",
+                )
+                .unwrap(),
+            )
+            .into_script(),
+        };
         assert!(!invalid_marker.is_openassets_marker());
 
         // can not parse varint
-        let invalid_marker = TxOut {value: 0, script_pubkey: Builder::from(hex_decode("6a4f410100ff").unwrap()).into_script()};
+        let invalid_marker = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(hex_decode("6a4f410100ff").unwrap()).into_script(),
+        };
         assert!(!invalid_marker.is_openassets_marker());
 
         // can not decode leb128 data(invalid format)
-        let invalid_marker = TxOut {value: 0, script_pubkey: Builder::from(hex_decode("6a4f410100018f8f").unwrap()).into_script()};
+        let invalid_marker = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(hex_decode("6a4f410100018f8f").unwrap()).into_script(),
+        };
         assert!(!invalid_marker.is_openassets_marker());
 
         // can not decode leb128 data(EOFError)
-        let invalid_marker = TxOut {value: 0, script_pubkey: Builder::from(hex_decode("6a4f410100028f7f").unwrap()).into_script()};
+        let invalid_marker = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(hex_decode("6a4f410100028f7f").unwrap()).into_script(),
+        };
         assert!(!invalid_marker.is_openassets_marker());
 
         // no metadata length
-        let invalid_marker = TxOut {value: 0, script_pubkey: Builder::from(hex_decode("6a4f410100018f7f").unwrap()).into_script()};
+        let invalid_marker = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(hex_decode("6a4f410100018f7f").unwrap()).into_script(),
+        };
         assert!(!invalid_marker.is_openassets_marker());
 
         // invalid metadata length
-        let invalid_marker = TxOut {value: 0, script_pubkey: Builder::from(hex_decode("6a4f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d").unwrap()).into_script()};
+        let invalid_marker = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(
+                hex_decode(
+                    "6a4f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d",
+                )
+                .unwrap(),
+            )
+            .into_script(),
+        };
         assert!(!invalid_marker.is_openassets_marker());
     }
 
     #[test]
-    fn test_get_oa_payload(){
+    fn test_get_oa_payload() {
         // valid marker
-        let marker_output = TxOut { value: 0, script_pubkey: Builder::from(hex_decode("6a244f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71").unwrap()).into_script() };
+        let marker_output = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(
+                hex_decode(
+                    "6a244f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71",
+                )
+                .unwrap(),
+            )
+            .into_script(),
+        };
         let payload: Payload = marker_output.get_oa_payload().unwrap();
         assert_eq!(vec![100, 0, 123], payload.quantities);
         assert_eq!("u=https://cpr.sm/5YgSU1Pg-q", payload.metadata);
 
         // empty metadata
-        let marker_output = TxOut { value: 0, script_pubkey: Builder::from(hex_decode("6a084f41010002014400").unwrap()).into_script() };
+        let marker_output = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(hex_decode("6a084f41010002014400").unwrap()).into_script(),
+        };
         let payload: Payload = marker_output.get_oa_payload().unwrap();
         assert_eq!(vec![1, 68], payload.quantities);
         assert_eq!("", payload.metadata);
 
         // test for leb128
-        let marker_output = TxOut { value: 0, script_pubkey: Builder::from(hex_decode("6a0b4f410100037f8001b96400").unwrap()).into_script() };
+        let marker_output = TxOut {
+            value: 0,
+            script_pubkey: Builder::from(hex_decode("6a0b4f410100037f8001b96400").unwrap())
+                .into_script(),
+        };
         let payload: Payload = marker_output.get_oa_payload().unwrap();
         assert_eq!(vec![127, 128, 12857], payload.quantities);
     }
@@ -198,19 +292,32 @@ mod tests {
     #[test]
     fn test_encode_payload() {
         let metadata = "u=https://cpr.sm/5YgSU1Pg-q".to_string();
-        let payload = Payload { quantities: vec![100, 0, 123], metadata };
+        let payload = Payload {
+            quantities: vec![100, 0, 123],
+            metadata,
+        };
         let result: Vec<u8> = serialize(&payload);
-        assert_eq!(hex_decode("4f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71").unwrap(), result);
+        assert_eq!(
+            hex_decode("4f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71")
+                .unwrap(),
+            result
+        );
 
         let metadata = "".to_string();
-        let payload = Payload { quantities: vec![1, 68], metadata };
-        let result:  Vec<u8> = serialize(&payload);
+        let payload = Payload {
+            quantities: vec![1, 68],
+            metadata,
+        };
+        let result: Vec<u8> = serialize(&payload);
         assert_eq!(hex_decode("4f41010002014400").unwrap(), result);
 
         // test for leb128
         let metadata = "".to_string();
-        let payload = Payload { quantities: vec![127, 128, 12857], metadata};
-        let result:  Vec<u8> = serialize(&payload);
+        let payload = Payload {
+            quantities: vec![127, 128, 12857],
+            metadata,
+        };
+        let result: Vec<u8> = serialize(&payload);
         assert_eq!(hex_decode("4f410100037f8001b96400").unwrap(), result);
     }
 }

--- a/src/openassets/mod.rs
+++ b/src/openassets/mod.rs
@@ -1,3 +1,3 @@
-pub mod marker_output;
-pub mod asset_id;
 pub mod address;
+pub mod asset_id;
+pub mod marker_output;


### PR DESCRIPTION
This PR allows metadata of the marker output to contain binary data.
This is tapyrus version of https://github.com/chaintope/openassets-rust/pull/1