### PR TITLE
Implement serialization for Metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ tapyrus = { git = "https://github.com/chaintope/rust-tapyrus/", features = ["use
 leb128 = "0.2.3"
 byteorder = "1.2"
 bitcoin_hashes = "0.3"
+serde = { version = "1.0"}
+serde_json = "1.0"
 
 [dependencies.hex]
 version = "=0.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,8 @@ extern crate byteorder;
 extern crate core;
 extern crate hex;
 extern crate tapyrus;
+extern crate serde;
+#[macro_use]
+extern crate serde_json;
 
 pub mod openassets;


### PR DESCRIPTION
This PR allows metadata to be displayed as hex string and utf8 string in json format.
This update is required for electrs-tapyrus.
https://github.com/chaintope/electrs-tapyrus/pull/6