### PR TITLE
Feature/add tests for unsupported script type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openassets-tapyrus"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["azuchi <azuchi@chaintope.com>"]
 license = "MIT"
 description = "The implementation of the Open Assets Protocol for Rust."

--- a/src/openassets/address.rs
+++ b/src/openassets/address.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 use tapyrus::consensus::encode;
+use tapyrus::hashes::hex::FromHex;
 use tapyrus::network::constants::Network;
 use tapyrus::util::address::Payload;
 use tapyrus::util::base58;
@@ -31,20 +32,51 @@ impl Address {
 
 impl Display for Address {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        let mut prefixed = [0; 22];
-        prefixed[0] = NAMESPACE;
-        prefixed[1] = match self.network {
-            tapyrus::network::constants::Network::Prod => 0,
-            tapyrus::network::constants::Network::Dev => 111,
-        };
         match self.payload {
             Payload::PubkeyHash(ref hash) => {
+                let mut prefixed = [0; 22];
+                prefixed[0] = NAMESPACE;
+                prefixed[1] = match self.network {
+                    Network::Prod => 0,
+                    Network::Dev => 111,
+                };
                 prefixed[2..].copy_from_slice(&hash[..]);
                 base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
             }
             Payload::ScriptHash(ref hash) => {
+                let mut prefixed = [0; 22];
+                prefixed[0] = NAMESPACE;
+                prefixed[1] = match self.network {
+                    Network::Prod => 5,
+                    Network::Dev => 196,
+                };
                 prefixed[2..].copy_from_slice(&hash[..]);
                 base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
+            }
+            Payload::ColoredPubkeyHash(ref color_id, ref hash) => {
+                let mut prefixed = [0; 55];
+                prefixed[0] = NAMESPACE;
+                prefixed[1] = match self.network {
+                    Network::Prod => 1,
+                    Network::Dev => 112,
+                };
+                prefixed[2..35].copy_from_slice(&Vec::from_hex(&format!("{}", color_id)).unwrap());
+                prefixed[35..].copy_from_slice(&hash[..]);
+                base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
+            }
+            Payload::ColoredScriptHash(ref color_id, ref hash) => {
+                let mut prefixed = [0; 55];
+                prefixed[0] = NAMESPACE;
+                prefixed[1] = match self.network {
+                    Network::Prod => 6,
+                    Network::Dev => 197,
+                };
+                prefixed[2..35].copy_from_slice(&Vec::from_hex(&format!("{}", color_id)).unwrap());
+                prefixed[35..].copy_from_slice(&hash[..]);
+                base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
+            }
+            _ => {
+                panic!("unsupported script type");
             }
         }
     }
@@ -65,25 +97,120 @@ mod tests {
     use openassets::address::OAAddressConverter;
     use std::str::FromStr;
     use std::string::ToString;
+    use tapyrus::network::constants::Network;
 
     #[test]
-    fn test_oa_address_converter() {
+    fn test_oa_address_for_p2kph() {
+        // for Prod
         let addr = tapyrus::Address::from_str("1F2AQr6oqNtcJQ6p9SiCLQTrHuM9en44H8").unwrap();
+        assert_eq!(addr.network, Network::Prod);
         assert_eq!(
             "akQz3f1v9JrnJAeGBC4pNzGNRdWXKan4U6E",
             addr.to_oa_address().unwrap().to_string()
         );
         assert_eq!(addr, addr.to_oa_address().unwrap().to_btc_addr().unwrap());
 
-        let testnet_addr =
-            tapyrus::Address::from_str("mkgW6hNYBctmqDtTTsTJrsf2Gh2NPtoCU4").unwrap();
+        // for Dev
+        let dev_addr = tapyrus::Address::from_str("mkgW6hNYBctmqDtTTsTJrsf2Gh2NPtoCU4").unwrap();
+        assert_eq!(dev_addr.network, Network::Dev);
         assert_eq!(
             "bWvePLsBsf6nThU3pWVZVWjZbcJCYQxHCpE",
-            testnet_addr.to_oa_address().unwrap().to_string()
+            dev_addr.to_oa_address().unwrap().to_string()
         );
         assert_eq!(
-            testnet_addr,
-            testnet_addr.to_oa_address().unwrap().to_btc_addr().unwrap()
+            dev_addr,
+            dev_addr.to_oa_address().unwrap().to_btc_addr().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_oa_address_for_p2sh() {
+        // for Prod
+        let addr = tapyrus::Address::from_str("3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX").unwrap();
+        assert_eq!(addr.network, Network::Prod);
+        assert_eq!(
+            "anQin2TDYaubr6M5MQM8kNXMitHc2hsmfGc",
+            addr.to_oa_address().unwrap().to_string()
+        );
+        assert_eq!(addr, addr.to_oa_address().unwrap().to_btc_addr().unwrap());
+        assert_eq!(addr, addr.to_oa_address().unwrap().to_btc_addr().unwrap());
+
+        // for Dev
+        let dev_addr = tapyrus::Address::from_str("2N6K6r2LEitDWRtYY2reSLcSQm2e2W9xEjB").unwrap();
+        assert_eq!(dev_addr.network, Network::Dev);
+        assert_eq!(
+            "c7GGz6C9aCN7CJ8hu5UkczULz6dpCWSBVnF",
+            dev_addr.to_oa_address().unwrap().to_string()
+        );
+        assert_eq!(
+            dev_addr,
+            dev_addr.to_oa_address().unwrap().to_btc_addr().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_oa_address_for_cp2pkh() {
+        // Color ID: c36db65fd59fd356f6729140571b5bcd6bb3b83492a16e1bf0a3884442fc3c8a0e
+        // PubkeyHash: 8f55563b9a19f321c211e9b9f38cdf686ea07845
+
+        // for Prod
+        let addr = tapyrus::Address::from_str(
+            "4Zxhb33iSoydtcKzWc7hpoRjtJh2W9otwDeqP5PbZHGoq7x6JndvyoFpAn5vzLCtLA5hyYTuJsH4gNP",
+        )
+        .unwrap();
+        assert_eq!(addr.network, Network::Prod);
+        assert_eq!(
+            "mJkjc5fgLN5sbo5FHJDj5M5YuhmRYNS8D8A5EFg4tRuohzLfNCNf4L1k7xBRm46mReKxkaUnpZutQyeJ",
+            addr.to_oa_address().unwrap().to_string()
+        );
+        assert_eq!(addr, addr.to_oa_address().unwrap().to_btc_addr().unwrap());
+
+        // for Dev
+        let dev_addr = tapyrus::Address::from_str(
+            "2oLaMRRokHWpeVx78biGm6DUnfgUdENWy4SnSrqtpy3U8h642g55gfJxhrcRdjmLdJ7hknTzUoorTUdC",
+        )
+        .unwrap();
+        assert_eq!(dev_addr.network, Network::Dev);
+        assert_eq!(
+            "o3XMFv4SNCnicQR2RPKt8cVbxV9D96eqHFPCqjSa7qg12rJmJZf6p1XT1e1mToXuAcHaoPQKQ4w1AmkL",
+            dev_addr.to_oa_address().unwrap().to_string()
+        );
+        assert_eq!(
+            dev_addr,
+            dev_addr.to_oa_address().unwrap().to_btc_addr().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_oa_address_for_cp2sh() {
+        // Color ID: c36db65fd59fd356f6729140571b5bcd6bb3b83492a16e1bf0a3884442fc3c8a0e
+        // ScriptHash: 8f55563b9a19f321c211e9b9f38cdf686ea07845
+
+        // for Prod
+        let addr = tapyrus::Address::from_str(
+            "4Zxhb33iSoydtcKzWc7hpoRjtJh2W9otwDeqP5PbZHGoq7x6JndvyoFpAn5vzLCtLA5hyYTuJsH4gNP",
+        )
+        .unwrap();
+        assert_eq!(addr.network, Network::Prod);
+        assert_eq!(
+            "mJkjc5fgLN5sbo5FHJDj5M5YuhmRYNS8D8A5EFg4tRuohzLfNCNf4L1k7xBRm46mReKxkaUnpZutQyeJ",
+            addr.to_oa_address().unwrap().to_string()
+        );
+        assert_eq!(addr, addr.to_oa_address().unwrap().to_btc_addr().unwrap());
+
+        // for Dev
+        let dev_addr = tapyrus::Address::from_str(
+            "2oLaMRRokHWpeVx78biGm6DUnfgUdENWy4SnSrqtpy3U8h642g55gfJxhrcRdjmLdJ7hknTzUoorTUdC",
+        )
+        .unwrap();
+        assert_eq!(dev_addr.network, Network::Dev);
+        assert_eq!(
+            "o3XMFv4SNCnicQR2RPKt8cVbxV9D96eqHFPCqjSa7qg12rJmJZf6p1XT1e1mToXuAcHaoPQKQ4w1AmkL",
+            dev_addr.to_oa_address().unwrap().to_string()
+        );
+        assert_eq!(
+            dev_addr,
+            dev_addr.to_oa_address().unwrap().to_btc_addr().unwrap()
         );
     }
 }


### PR DESCRIPTION
Rust tapyrus > 0.4.4 supports colored coin feature and its address(cp2pkh, cp2sh) in tapyrus::Address
This PR add OA address for cp2pkh and cp2sh.
